### PR TITLE
formatter: fix issue where formatter may not register properly

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,41 +1,36 @@
-import * as vscode from 'vscode';
-import { exec } from 'child_process';
+import { exec } from "child_process";
+import * as vscode from "vscode";
 
-export function activate(context: vscode.ExtensionContext) {
-	var installed: Boolean = false;
-	//check if alloy is installed
-	exec("alloy --version", (error, stdout, stderr) => {
-		if (error || stderr) {
-			vscode.window.showWarningMessage(`Alloy is not installed. Please install it from https://grafana.com/docs/alloy/latest/set-up/install/`);
-		}
-		if (stdout) {
-			vscode.window.showInformationMessage(`Alloy is installed: ${stdout}`);
-			installed = true;
-		}
-	});
-	//if alloy is installed, register the formatter
-	if (installed) {
-		vscode.languages.registerDocumentFormattingEditProvider('grafana-alloy', {
-			provideDocumentFormattingEdits(document: vscode.TextDocument): vscode.TextEdit[] {
-				// nothing fancy, just run the command
-				exec("alloy fmt -w " + document.fileName, (error, stdout, stderr) => {
-					if (error) {
-						vscode.window.showErrorMessage(`Error: ${error.message}`);
-						return [];
-					}
-					if (stderr) {
-						vscode.window.showErrorMessage(`Error: ${stderr}`);
-						return [];
-					}
-					if (stdout) {
-						vscode.window.showInformationMessage(`Formatted: ${stdout}`);
-						return [];
-					}
-				});
-				return [];
-			}
-		});
-	}
+export function activate(_: vscode.ExtensionContext) {
+  // Register a formatter if Alloy is installed.
+  exec("alloy --version", (error, stdout, stderr) => {
+    if (error || stderr) {
+      vscode.window.showWarningMessage(
+        `Alloy is not installed. Please install it from https://grafana.com/docs/alloy/latest/set-up/install/`
+      );
+      return;
+    }
+
+    vscode.window.showInformationMessage(`Alloy is installed: ${stdout}`);
+
+    vscode.languages.registerDocumentFormattingEditProvider("grafana-alloy", {
+      provideDocumentFormattingEdits(
+        document: vscode.TextDocument
+      ): vscode.TextEdit[] {
+        exec("alloy fmt -w " + document.fileName, (error, stdout, stderr) => {
+          if (error) {
+            vscode.window.showErrorMessage(`Error: ${error.message}`);
+          } else if (stderr) {
+            vscode.window.showErrorMessage(`Error: ${stderr}`);
+          } else if (stdout) {
+            vscode.window.showInformationMessage(`Formatted: ${stdout}`);
+          }
+        });
+
+        return [];
+      },
+    });
+  });
 }
 
-export function deactivate() { }
+export function deactivate() {}


### PR DESCRIPTION
Previously, the formatter was only registered if the callback for `exec` happened to execute prior to the check for the install, which I couldn't get this to happen consistently on my machine.

To fix this, registering the formatter is now done in the exec callback.

I've made some minor other style tweaks as well.